### PR TITLE
各ニュース項目に参照元リンクを追加

### DIFF
--- a/src/news_curator.py
+++ b/src/news_curator.py
@@ -157,11 +157,16 @@ class NewsCurator:
 
     def _format_source_link(self, chunk: dict) -> str:
         """Format a single source link for Slack mrkdwn."""
-        title = chunk.get("title", "リンク")
-        uri = chunk.get("uri", "")
-        if uri:
-            return f"<{uri}|{title}>"
-        return ""
+        title = chunk.get("title")
+        uri = chunk.get("uri")
+        if not uri:
+            if title:
+                logger.warning(
+                    "Grounding chunk has title but no URI; omitting source link: %s",
+                    chunk,
+                )
+            return ""
+        return f"<{uri}|{title or 'リンク'}>"
 
     def _append_all_sources(self, text: str, chunks: list[dict]) -> str:
         """Append all sources at the end of the text."""


### PR DESCRIPTION
## Summary
- grounding_supports メタデータを使用して各ニュース項目に対応する参照元リンクを追加
- テキストセグメントの位置に基づいてソースURLをマッピング
- 感想セクション（最後のパート）には参照元を表示しない

## Changes
- `_insert_sources_per_item()`: 各ニュース項目の末尾に参照元リンクを挿入
- `_extract_grounding_metadata()`: grounding_supports からセグメント情報を抽出
- 最後のセクション（ボクの感想なのだ）には参照元を追加しない処理

## Test plan
- [ ] ローカルで実行して各項目に参照元が表示されることを確認
- [ ] 感想セクションに参照元が表示されないことを確認
- [ ] 参照元リンクがクリック可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)