### PR TITLE
Truncate header text to 150 characters for Slack Block Kit

### DIFF
--- a/src/slack_poster.py
+++ b/src/slack_poster.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 MAX_BLOCK_TEXT_LENGTH = 3000
+MAX_HEADER_LENGTH = 150
 HISTORY_DAYS = 7
 
 
@@ -57,13 +58,19 @@ class SlackPoster:
         date_str = now.strftime("%Y年%-m月%-d日")
         time_str = now.strftime("%H:%M UTC")
 
+        # Header は 150 文字以下に制限
+        header_text = self.header
+        if len(header_text) > MAX_HEADER_LENGTH:
+            header_text = header_text[: MAX_HEADER_LENGTH - 3] + "..."
+            logger.warning(f"Truncated header to {MAX_HEADER_LENGTH} characters")
+
         blocks = [
             # ヘッダー
             {
                 "type": "header",
                 "text": {
                     "type": "plain_text",
-                    "text": self.header,
+                    "text": header_text,
                     "emoji": True,
                 },
             },

--- a/src/slack_poster.py
+++ b/src/slack_poster.py
@@ -92,12 +92,18 @@ class SlackPoster:
             blocks.append({"type": "divider"})
 
             # ニュース本文（タイトル + 説明 + 補足情報）
+            # Section text は 3000 文字以下に制限
+            text = item.text
+            if len(text) > MAX_BLOCK_TEXT_LENGTH:
+                text = text[: MAX_BLOCK_TEXT_LENGTH - 3] + "..."
+                logger.warning(f"Truncated section text to {MAX_BLOCK_TEXT_LENGTH} characters")
+
             blocks.append(
                 {
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": item.text,
+                        "text": text,
                     },
                 }
             )


### PR DESCRIPTION
## Summary
Slack Block Kit の文字数制限に対応し、`invalid_blocks` エラーを防止

## Changes

### 1. Header の切り詰め (150文字制限)
- `MAX_HEADER_LENGTH = 150` 定数を追加
- header が 150 文字を超える場合は切り詰めて `...` を付加

### 2. Section text の切り詰め (3000文字制限)
- 既存の `MAX_BLOCK_TEXT_LENGTH = 3000` を使用
- section text が 3000 文字を超える場合は切り詰めて `...` を付加

## Test plan
- [ ] 長い header でもエラーが発生しないことを確認
- [ ] 長い section text でもエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)