### PR TITLE
Add date context to prompt and filter old sources

### DIFF
--- a/src/news_curator.py
+++ b/src/news_curator.py
@@ -8,7 +8,7 @@ from .config import Config, TopicConfig
 
 logger = logging.getLogger(__name__)
 
-PROMPT_TEMPLATE = """本日は {current_date} です。「{topic}」に関する過去24時間以内（{date_range_start} 以降）のニュースを検索し、「ずんだもん」と「あんこもん」の2人が議論する形式でSlack mrkdwn形式で報告してください。
+PROMPT_TEMPLATE = """本日は {current_date} です。「{topic}」に関する{time_period}（{date_range_start} 以降）のニュースを検索し、「ずんだもん」と「あんこもん」の2人が議論する形式でSlack mrkdwn形式で報告してください。
 
 # ずんだもんの設定
 - ずんだ餅の妖精
@@ -127,9 +127,13 @@ class NewsCurator:
             zundamon = "ずんだもん"
             ankomon = "あんこもん"
 
-        # 現在の日時と24時間前の日時を計算
+        # 現在の日時と検索期間の開始日時を計算
+        # 月曜日は土日の分も含めて72時間、それ以外は24時間
         now = datetime.now(timezone.utc)
-        date_range_start = now - timedelta(hours=24)
+        is_monday = now.weekday() == 0
+        hours_back = 72 if is_monday else 24
+        time_period = "過去72時間以内（土日を含む）" if is_monday else "過去24時間以内"
+        date_range_start = now - timedelta(hours=hours_back)
         current_date = now.strftime("%Y年%m月%d日 %H:%M UTC")
         date_range_start_str = date_range_start.strftime("%Y年%m月%d日 %H:%M UTC")
 
@@ -139,6 +143,7 @@ class NewsCurator:
             zundamon=zundamon,
             ankomon=ankomon,
             current_date=current_date,
+            time_period=time_period,
             date_range_start=date_range_start_str,
         )
 

--- a/src/news_curator.py
+++ b/src/news_curator.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta, timezone
 
 from google import genai
 from google.genai import types
@@ -7,7 +8,7 @@ from .config import Config, TopicConfig
 
 logger = logging.getLogger(__name__)
 
-PROMPT_TEMPLATE = """「{topic}」に関する過去24時間以内のニュースを検索し、「ずんだもん」と「あんこもん」の2人が議論する形式でSlack mrkdwn形式で報告してください。
+PROMPT_TEMPLATE = """本日は {current_date} です。「{topic}」に関する過去24時間以内（{date_range_start} 以降）のニュースを検索し、「ずんだもん」と「あんこもん」の2人が議論する形式でSlack mrkdwn形式で報告してください。
 
 # ずんだもんの設定
 - ずんだ餅の妖精
@@ -126,11 +127,19 @@ class NewsCurator:
             zundamon = "ずんだもん"
             ankomon = "あんこもん"
 
+        # 現在の日時と24時間前の日時を計算
+        now = datetime.now(timezone.utc)
+        date_range_start = now - timedelta(hours=24)
+        current_date = now.strftime("%Y年%m月%d日 %H:%M UTC")
+        date_range_start_str = date_range_start.strftime("%Y年%m月%d日 %H:%M UTC")
+
         prompt = PROMPT_TEMPLATE.format(
             topic=topic,
             exclude_section=exclude_section,
             zundamon=zundamon,
             ankomon=ankomon,
+            current_date=current_date,
+            date_range_start=date_range_start_str,
         )
 
         logger.info(f"Fetching news for topic: {topic}")


### PR DESCRIPTION
## Summary

ニュース検索の日付精度を向上させるための改善。

## Commits

### 1. プロンプトに日付を明示
- 現在日時と検索開始日時をプロンプトに追加
- LLM が正確な時間範囲を理解できるように

### 2. grounding metadata の日付フィルタリング
- grounding metadata から日付情報を抽出（利用可能な場合）
- 検索期間より古いソースを除外

### 3. 月曜日は72時間に拡張
- 月曜日: 過去72時間（土日を含む）
- 火〜金: 過去24時間

## Test plan

- [ ] 平日に24時間以内のニュースが取得されることを確認
- [ ] 月曜日に72時間以内のニュースが取得されることを確認
- [ ] 古いソースがフィルタリングされることを確認（日付情報がある場合）

🤖 Generated with [Claude Code](https://claude.com/claude-code)