### PR TITLE
Add configurable Slack URL unfurl options

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ SLACK_BOT_TOKEN=xoxb-your-bot-token
 
 # 方式1: マルチトピックモード (推奨)
 # JSON配列形式で複数トピックを設定
-# TOPICS_CONFIG='[{"name":"AI生成ゲーム","channel_id":"C0XXXXXXX","header":"AI生成ゲーム ニュース"},{"name":"LLM","channel_id":"C0YYYYYYY","header":"LLM ニュース"}]'
+# 各トピックごとに unfurl_links, unfurl_media を設定可能（オプション、デフォルト: false）
+# TOPICS_CONFIG='[{"name":"AI生成ゲーム","channel_id":"C0XXXXXXX","header":"AI生成ゲーム ニュース","unfurl_links":true},{"name":"LLM","channel_id":"C0YYYYYYY","header":"LLM ニュース"}]'
 
 # 方式2: シングルトピックモード (レガシー)
 # TOPICS_CONFIG が未設定の場合に使用される
@@ -25,3 +26,9 @@ MODEL_NAME=gemini-2.5-pro
 # Optional: Display settings
 # Slack絵文字を使用する場合は true に設定 (:zundamon:, :ankomon:)
 USE_EMOJI_NAMES=false
+
+# Optional: Slack URL unfurl settings (シングルトピックモード用)
+# マルチトピックモードでは TOPICS_CONFIG 内で各トピックごとに設定
+# URL のプレビュー展開を有効にする場合は true に設定
+SLACK_UNFURL_LINKS=false
+SLACK_UNFURL_MEDIA=false

--- a/.github/workflows/daily-news-curator.yml
+++ b/.github/workflows/daily-news-curator.yml
@@ -35,7 +35,8 @@ jobs:
           MODEL_NAME: ${{ vars.MODEL_NAME != '' && vars.MODEL_NAME || 'gemini-2.5-pro' }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           # Multi-topic configuration (JSON array)
-          # Example: [{"name": "生成AI", "channel_id": "C123...", "header": "🤖 生成AI ニュース"}]
+          # Example: [{"name": "生成AI", "channel_id": "C123...", "header": "🤖 生成AI ニュース", "unfurl_links": true}]
+          # unfurl_links, unfurl_media can be set per topic (optional, default: false)
           TOPICS_CONFIG: ${{ vars.TOPICS_CONFIG }}
           # Legacy single-topic mode (used if TOPICS_CONFIG is not set)
           CURATOR_TOPIC: ${{ vars.CURATOR_TOPIC }}
@@ -43,4 +44,8 @@ jobs:
           SLACK_HEADER: ${{ vars.SLACK_HEADER }}
           # Display settings
           USE_EMOJI_NAMES: ${{ vars.USE_EMOJI_NAMES != '' && vars.USE_EMOJI_NAMES || 'false' }}
+          # Slack URL unfurl settings (for legacy single-topic mode)
+          # For multi-topic mode, set unfurl_links/unfurl_media in TOPICS_CONFIG
+          SLACK_UNFURL_LINKS: ${{ vars.SLACK_UNFURL_LINKS != '' && vars.SLACK_UNFURL_LINKS || 'false' }}
+          SLACK_UNFURL_MEDIA: ${{ vars.SLACK_UNFURL_MEDIA != '' && vars.SLACK_UNFURL_MEDIA || 'false' }}
         run: uv run python -m src.main

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,15 @@ import os
 from dataclasses import dataclass
 
 
+def _parse_bool(value) -> bool:
+    """Parse a boolean value from various types."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).lower() == "true"
+
+
 @dataclass
 class TopicConfig:
     """Configuration for a single topic."""
@@ -10,6 +19,8 @@ class TopicConfig:
     name: str
     channel_id: str
     header: str
+    unfurl_links: bool = False
+    unfurl_media: bool = False
 
     @classmethod
     def from_dict(cls, data: dict) -> "TopicConfig":
@@ -23,7 +34,15 @@ class TopicConfig:
             raise ValueError("Topic 'channel_id' is required")
 
         header = data.get("header") or f"{name} ニュース"
-        return cls(name=name, channel_id=channel_id, header=header)
+        unfurl_links = _parse_bool(data.get("unfurl_links", False))
+        unfurl_media = _parse_bool(data.get("unfurl_media", False))
+        return cls(
+            name=name,
+            channel_id=channel_id,
+            header=header,
+            unfurl_links=unfurl_links,
+            unfurl_media=unfurl_media,
+        )
 
 
 @dataclass
@@ -90,5 +109,15 @@ class Config:
             raise ValueError("SLACK_CHANNEL_ID environment variable is required")
 
         header = os.environ.get("SLACK_HEADER") or f"{topic} ニュース"
+        unfurl_links = _parse_bool(os.environ.get("SLACK_UNFURL_LINKS", False))
+        unfurl_media = _parse_bool(os.environ.get("SLACK_UNFURL_MEDIA", False))
 
-        return [TopicConfig(name=topic, channel_id=channel_id, header=header)]
+        return [
+            TopicConfig(
+                name=topic,
+                channel_id=channel_id,
+                header=header,
+                unfurl_links=unfurl_links,
+                unfurl_media=unfurl_media,
+            )
+        ]

--- a/src/slack_poster.py
+++ b/src/slack_poster.py
@@ -26,6 +26,8 @@ class SlackPoster:
         self.channel_id = topic.channel_id
         self.header = topic.header
         self.model_name = config.model_name
+        self.unfurl_links = topic.unfurl_links
+        self.unfurl_media = topic.unfurl_media
 
     def post_news(self, items: list["NewsItem"]) -> bool:
         """Post news items to Slack using Block Kit.
@@ -43,8 +45,8 @@ class SlackPoster:
                 channel=self.channel_id,
                 blocks=blocks,
                 text=self.header,
-                unfurl_links=False,
-                unfurl_media=False,
+                unfurl_links=self.unfurl_links,
+                unfurl_media=self.unfurl_media,
             )
             logger.info(f"Message posted successfully: {response['ts']}")
             return True


### PR DESCRIPTION
## Summary
- Slack投稿時のURL展開（unfurl）を通知先ごとに個別設定可能に
- `TopicConfig` に `unfurl_links` と `unfurl_media` を追加
- デフォルトは `false`（現在の挙動を維持）

## 設定方法

### マルチトピックモード（推奨）
`TOPICS_CONFIG` の各トピックに `unfurl_links`, `unfurl_media` を追加:
```json
[
  {"name": "AI", "channel_id": "C123...", "header": "AI ニュース", "unfurl_links": true},
  {"name": "LLM", "channel_id": "C456...", "header": "LLM ニュース", "unfurl_links": false}
]
```

### シングルトピックモード（レガシー）
環境変数で設定:
```
SLACK_UNFURL_LINKS=true
SLACK_UNFURL_MEDIA=true
```

### CI（GitHub Actions）
- マルチトピックモード: `vars.TOPICS_CONFIG` 内で各トピックごとに設定
- シングルトピックモード: `vars.SLACK_UNFURL_LINKS`, `vars.SLACK_UNFURL_MEDIA` を設定

## Test plan
- [ ] マルチトピックモードで、トピックAは `unfurl_links=true`、トピックBは `unfurl_links=false` で個別に動作することを確認
- [ ] シングルトピックモードで `SLACK_UNFURL_LINKS=true` が有効になることを確認
- [ ] デフォルト（未設定）でURL展開が無効のままであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)