### PR TITLE
Remove legacy single-topic mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,18 +7,10 @@ GCP_LOCATION=asia-northeast1
 # Slack
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 
-# Topic Configuration (2つの方式から選択)
-
-# 方式1: マルチトピックモード (推奨)
+# Topic Configuration
 # JSON配列形式で複数トピックを設定
 # 各トピックごとに unfurl_links, unfurl_media を設定可能（オプション、デフォルト: false）
-# TOPICS_CONFIG='[{"name":"AI生成ゲーム","channel_id":"C0XXXXXXX","header":"AI生成ゲーム ニュース","unfurl_links":true},{"name":"LLM","channel_id":"C0YYYYYYY","header":"LLM ニュース"}]'
-
-# 方式2: シングルトピックモード (レガシー)
-# TOPICS_CONFIG が未設定の場合に使用される
-CURATOR_TOPIC=AI生成ゲーム
-SLACK_CHANNEL_ID=C0XXXXXXX
-SLACK_HEADER=
+TOPICS_CONFIG='[{"name":"AI生成ゲーム","channel_id":"C0XXXXXXX","header":"AI生成ゲーム ニュース","unfurl_links":true},{"name":"LLM","channel_id":"C0YYYYYYY","header":"LLM ニュース"}]'
 
 # Optional: Model configuration
 MODEL_NAME=gemini-2.5-pro
@@ -26,9 +18,3 @@ MODEL_NAME=gemini-2.5-pro
 # Optional: Display settings
 # Slack絵文字を使用する場合は true に設定 (:zundamon:, :ankomon:)
 USE_EMOJI_NAMES=false
-
-# Optional: Slack URL unfurl settings (シングルトピックモード用)
-# マルチトピックモードでは TOPICS_CONFIG 内で各トピックごとに設定
-# URL のプレビュー展開を有効にする場合は true に設定
-SLACK_UNFURL_LINKS=false
-SLACK_UNFURL_MEDIA=false

--- a/.github/workflows/daily-news-curator.yml
+++ b/.github/workflows/daily-news-curator.yml
@@ -34,18 +34,10 @@ jobs:
           GCP_LOCATION: ${{ vars.GCP_LOCATION != '' && vars.GCP_LOCATION || 'asia-northeast1' }}
           MODEL_NAME: ${{ vars.MODEL_NAME != '' && vars.MODEL_NAME || 'gemini-2.5-pro' }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          # Multi-topic configuration (JSON array)
+          # Topic configuration (JSON array)
           # Example: [{"name": "生成AI", "channel_id": "C123...", "header": "🤖 生成AI ニュース", "unfurl_links": true}]
           # unfurl_links, unfurl_media can be set per topic (optional, default: false)
           TOPICS_CONFIG: ${{ vars.TOPICS_CONFIG }}
-          # Legacy single-topic mode (used if TOPICS_CONFIG is not set)
-          CURATOR_TOPIC: ${{ vars.CURATOR_TOPIC }}
-          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
-          SLACK_HEADER: ${{ vars.SLACK_HEADER }}
           # Display settings
           USE_EMOJI_NAMES: ${{ vars.USE_EMOJI_NAMES != '' && vars.USE_EMOJI_NAMES || 'false' }}
-          # Slack URL unfurl settings (for legacy single-topic mode)
-          # For multi-topic mode, set unfurl_links/unfurl_media in TOPICS_CONFIG
-          SLACK_UNFURL_LINKS: ${{ vars.SLACK_UNFURL_LINKS != '' && vars.SLACK_UNFURL_LINKS || 'false' }}
-          SLACK_UNFURL_MEDIA: ${{ vars.SLACK_UNFURL_MEDIA != '' && vars.SLACK_UNFURL_MEDIA || 'false' }}
         run: uv run python -m src.main

--- a/src/config.py
+++ b/src/config.py
@@ -74,7 +74,7 @@ class Config:
             model_name=os.environ.get("MODEL_NAME", "gemini-2.5-pro"),
             slack_bot_token=os.environ["SLACK_BOT_TOKEN"],
             topics=topics,
-            use_emoji_names=os.environ.get("USE_EMOJI_NAMES", "").lower() == "true",
+            use_emoji_names=_parse_bool(os.environ.get("USE_EMOJI_NAMES", False)),
         )
 
     @classmethod


### PR DESCRIPTION
## Summary
- レガシーのシングルトピックモードを完全に削除
- `TOPICS_CONFIG` 環境変数が必須に

## BREAKING CHANGE

以下の環境変数は使用できなくなります：
- `CURATOR_TOPIC`
- `SLACK_CHANNEL_ID`
- `SLACK_HEADER`
- `SLACK_UNFURL_LINKS`
- `SLACK_UNFURL_MEDIA`

## Migration

シングルトピックモードを使用していた場合は、`TOPICS_CONFIG` に移行してください：

**Before:**
```
CURATOR_TOPIC=AI生成ゲーム
SLACK_CHANNEL_ID=C0XXXXXXX
SLACK_HEADER=AI ニュース
SLACK_UNFURL_LINKS=true
```

**After:**
```
TOPICS_CONFIG='[{"name":"AI生成ゲーム","channel_id":"C0XXXXXXX","header":"AI ニュース","unfurl_links":true}]'
```

## Test plan
- [ ] `TOPICS_CONFIG` が設定されていない場合にエラーになることを確認
- [ ] `TOPICS_CONFIG` が正しく設定されている場合に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)